### PR TITLE
fix libssl deps for newer distributions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ def DEFAULT_DEPS = [
                 ['libc6'],
                 ['libgcc1'],
                 ['libstdc++6'],
-                [primary:['libssl1.1'], or:['libssl3']],
+                [primary:['libssl1.1'], or:['libssl3'], or:['libssl3t64']],
                 ['libcurl4'],
                 [primary:['python3-mapbox-earcut'], or:['base-files','12',org.redline_rpm.header.Flags.LESS]],
                 ['gdal-bin'],

--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ def DEFAULT_DEPS = [
                 ['libc6'],
                 ['libgcc1'],
                 ['libstdc++6'],
-                ['libssl1.1'],
+                [primary:['libssl1.1'], or:['libssl3']],
                 ['libcurl4'],
                 [primary:['python3-mapbox-earcut'], or:['base-files','12',org.redline_rpm.header.Flags.LESS]],
                 ['gdal-bin'],


### PR DESCRIPTION
Hi @wellenvogel ,

newer distribution (Debian/Bookworm, Ubuntu/Noble) don't have libssl1.1 package. This PR fixes requirement for newer libssl

Kind regards
free-x 